### PR TITLE
Supply a User-Agent for pub.dev

### DIFF
--- a/lib/src/pub_client.dart
+++ b/lib/src/pub_client.dart
@@ -19,7 +19,7 @@ class PubClient {
     final url = Uri.parse(
         'https://pub.dev/api/packages/${Uri.encodeComponent(name)}/score');
     final req = Request('GET', url);
-    req.headers['User-Agent'] = 'badges.bar/0.0.2 (+https://badges.bar/)'
+    req.headers['User-Agent'] = 'badges.bar/0.0.2 (+https://badges.bar/)';
     final streamedResponse = await httpClient.send(req);
     final response = await Response.fromStream(streamedResponse);
 

--- a/lib/src/pub_client.dart
+++ b/lib/src/pub_client.dart
@@ -18,7 +18,9 @@ class PubClient {
   Future<Score> getScore(String name) async {
     final url = Uri.parse(
         'https://pub.dev/api/packages/${Uri.encodeComponent(name)}/score');
-    final streamedResponse = await httpClient.send(Request('GET', url));
+    final req = Request('GET', url);
+    req.headers['User-Agent'] = 'badges.bar/0.0.2 (+https://badges.bar/)'
+    final streamedResponse = await httpClient.send(req);
     final response = await Response.fromStream(streamedResponse);
 
     if (streamedResponse.statusCode == 404) {


### PR DESCRIPTION
It's always preferable to have a user-agent that helps pub.dev track down API consumers.

This is particularly useful if we are making breaking changes to an API :)

Beyond APIs specified in: https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md
pub.dev does not offer any stable APIs as of writing.