### PR TITLE
Fix mixup of popularity and points

### DIFF
--- a/lib/src/pub_client.dart
+++ b/lib/src/pub_client.dart
@@ -45,13 +45,17 @@ class PubClient {
     if (likes == null || popularity == null || points == null) {
       throw 'Unexpected valyes: likes: "$likes" popularity: "$popularity" points: "$points"';
     }
-    return Score(likes, (popularity * 100).round(), points);
+    return Score(
+      likes: likes,
+      points: points,
+      popularity: (popularity * 100).round(),
+    );
   }
 }
 
 /// Scores of a package on pub.dev.
 class Score {
-  const Score(this.likes, this.points, this.popularity);
+  const Score({this.likes, this.points, this.popularity});
 
   /// Package 'Likes'.
   final int likes;

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -1,7 +1,7 @@
+import 'package:badges_bar/badges_bar.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:badges_bar/badges_bar.dart';
 
 void main() {
   test('svg renders with title and value', () {
@@ -18,8 +18,8 @@ void main() {
       final sut = PubClient(MockClient((r) async => _validResponse));
       final scores = await sut.getScore('badges_bar');
       expect(scores.likes, 1);
-      expect(scores.popularity, 2);
-      expect(scores.points, 3);
+      expect(scores.points, 2);
+      expect(scores.popularity, 3);
     });
     test('pub.dev changed score payload, throws error', () async {
       final sut = PubClient(MockClient((r) async =>
@@ -71,13 +71,13 @@ void main() {
 
   group('Score', () {
     test('returns expected score through getValueByType', () {
-      const sut = Score(1, 2, 3);
+      const sut = Score(likes: 1, points: 2, popularity: 3);
       expect(sut.getValueByType('likes'), 1);
       expect(sut.getValueByType('pub points'), 2);
       expect(sut.getValueByType('popularity'), 3);
     });
     test('getValueByType throws on unknown type', () {
-      const sut = Score(1, 2, 3);
+      const sut = Score(likes: 1, points: 2, popularity: 3);
       expect(
           () => sut.getValueByType('wut?'),
           throwsA(


### PR DESCRIPTION
Fixes https://github.com/bruno-garcia/badges.bar/issues/6

Also changes the default `Score` constructor to use named arguments. They are great for preventing exactly these kinds of mixups.