### PR TITLE
Update Sentry to v6 beta

### DIFF
--- a/bin/server.dart
+++ b/bin/server.dart
@@ -16,6 +16,7 @@ Future<void> main() async {
     o.release = Platform.environment['VERSION'];
     o.environment = Platform.environment['ENVIRONMENT'];
     o.debug = !isProduction;
+    o.enablePrintBreadcrumbs = false;
   });
 
   // Should go into Sentry

--- a/lib/src/pub_client.dart
+++ b/lib/src/pub_client.dart
@@ -11,7 +11,10 @@ import 'version.dart';
 class PubClient {
   /// Creates an instance of [PubClient] using an optional [HttpClient].
   PubClient([this.httpClient]) {
-    httpClient ??= SentryHttpClient();
+    httpClient ??= SentryHttpClient(
+      captureFailedRequests: true,
+      failedRequestStatusCodes: [SentryStatusCode.range(400, 500)],
+    );
   }
 
   Client httpClient;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,7 +203,7 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0-beta.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  sentry: ^5.0.0
+  sentry: ^6.0.0-beta.1
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Updates Sentry to v6 beta and enables sending crash reports for "bad" requests.